### PR TITLE
This commit fixes a warning caused by the docker update

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   bot:
     build:


### PR DESCRIPTION
Вылетало предупреждение)
![image](https://github.com/Luganskii/ImageEnhanceBot/assets/57844571/51f66fc7-c621-41e4-96d7-5c787c530bab)

Чтобы его исправить я воспользовался [советом](https://github.com/mailcow/mailcow-dockerized/issues/5797)
![image](https://github.com/Luganskii/ImageEnhanceBot/assets/57844571/cb68a623-7d3a-4fe7-9141-050c817debd9)
